### PR TITLE
Include initrd mounts in the final system also

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -247,8 +247,12 @@ rec {
     let
       allDirectories = getAllDirectories stateConfig;
       allFiles = getAllFiles stateConfig;
-      mountedDirectories = onlyBindMounts forInitrd allDirectories;
-      mountedFiles = onlyBindMounts forInitrd allFiles;
+      mountedDirectories =
+        onlyBindMounts forInitrd allDirectories
+        ++ lib.optionals (!forInitrd) (onlyBindMounts true allDirectories);
+      mountedFiles =
+        onlyBindMounts forInitrd allFiles
+        ++ lib.optionals (!forInitrd) (onlyBindMounts true allFiles);
 
       prefix = if forInitrd then "/sysroot" else "/";
 


### PR DESCRIPTION
Without this, things like `RequiresMountsFor` do not work correctly during shutdown.

See https://github.com/systemd/systemd/pull/34327

Fixes #2 
