### PR TITLE
support user-specific paths with the respective user as owner of non-persisted intermediate/parent paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,12 @@ jobs:
           diagnostic-endpoint: ""
           source-url: "https://install.lix.systems/lix/lix-installer-x86_64-linux"
 
-      - run: nix flake check --log-format raw-with-logs -L ./tests
+      - name: flake-check --no-build
+        run: nix flake check --log-format raw-with-logs --no-build ./tests
+      - name: default test
+        run: nix build --log-format raw-with-logs -L ./tests#checks.x86_64-linux.default
+      - name: firstboot test
+        run: nix build --log-format raw-with-logs -L ./tests#checks.x86_64-linux.firstboot
 
 env:
   FORCE_COLOR: 1

--- a/docs/src/impermanence-migration.md
+++ b/docs/src/impermanence-migration.md
@@ -11,6 +11,36 @@ impermanence configuration to Preservation:
 
 The module must be explicitly enabled by setting `preservation.enable` to `true`.
 
+### Handling of existing state
+
+Coming from a setup with impermanence it is important to make sure existing persistent state is preserved
+correctly, meaning the ownership and mode of preservation remains the same. There is no exhaustive list
+of files and directories requiring special treatment but at least the following needs to be considered:
+
+**SSH host keys**
+
+Correct ownership and mode of SSH host keys is very important for sshd to accept connections.
+Getting this wrong, e.g. not restricted enough, may cause your host to become inaccessible via SSH, forcing
+you to use other means of logging into the machine.
+
+The following config may be used to preserve the RSA and Ed25519 host keys with preservation:
+
+```nix
+preservation.preserveAt."/persistent".files = [
+  { file = "/etc/ssh/ssh_host_rsa_key"; how = "symlink"; configureParent = true; }
+  { file = "/etc/ssh/ssh_host_ed25519_key"; how = "symlink"; configureParent = true; }
+];
+```
+
+The above config does not include access modes for the key files because the preservation
+mode is `symlink` and the link's target is not touched by preservation without an explicit
+`createLinkTarget = true`.
+
+**Secrets and other files requiring special access modes**
+
+Any files and directories that need to have a mode that differs from the default (`0644` for files
+and `0755` for directories) must be configured explicitly to avoid having the default mode applied.
+
 ### When to persist
 
 Files and directories that need to be persisted early, must be explicitly configured. For example `/etc/machine-id`:

--- a/tests/appliance-image-verity.nix
+++ b/tests/appliance-image-verity.nix
@@ -125,7 +125,7 @@ pkgs:
         "-f",
         "qcow2",
         "-b",
-        "${nodes.machine.system.build.finalImage}/${nodes.machine.image.repart.imageFile}",
+        "${nodes.machine.system.build.finalImage}/${nodes.machine.image.fileName}",
         "-F",
         "raw",
         tmp_disk_image.name,

--- a/tests/flake.lock
+++ b/tests/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738142207,
-        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "lastModified": 1751271578,
+        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
* motivated by #9 and meant as an alternative implementation to #12 

(see individual commit messages)