### PR TITLE
fix tmpfiles `0755` permissions conflict on split roots for subdirs

### DIFF
--- a/options.nix
+++ b/options.nix
@@ -354,11 +354,11 @@ let
             definedDirectories:
             let
               intermediateDirectorySettings = {
-                how = "_intermediate";
-                configureParent = false;
-                user = attrs.config.username;
-                group = config.users.users.${attrs.config.username}.group;
-                mode = "0755";
+                how = lib.mkDefault "_intermediate";
+                configureParent = lib.mkDefault  false;
+                user = lib.mkDefault attrs.config.username;
+                group = lib.mkDefault config.users.users.${attrs.config.username}.group;
+                mode = lib.mkDefault "0755";
               };
               allDirectories =
                 mkIntermediateUserDirectories intermediateDirectorySettings attrs.config.files attrs.config.home


### PR DESCRIPTION
fixes https://github.com/nix-community/preservation/issues/20

This is MVP that works for me, not 100% sure it's "conceptually" correct.

The reasoning behind it can be found in the linked issue.


Turns

```nix
nix-repl> :p lib.pipe nixosConfigurations.brys.config.preservation.preserveAt [(lib.mapAttrsToList (k: e: e.users.kdn.directories)) lib.flatten (builtins.filter (e: e.directory == "/home/kdn/.local/share/bottles"))]
[
  {
    configureParent = false;
    directory = "/home/kdn/.local/share/bottles";
    group = "users";
    how = "_intermediate";
    inInitrd = false;
    mode = "0755";
    user = "kdn";
  }
  {
    configureParent = false;
    createLinkTarget = false;
    directory = "/home/kdn/.local/share/bottles";
    group = "users";
    how = "bindmount";
    inInitrd = false;
    mode = "0750";
    mountOptions = [
      {
        name = "bind";
        value = null;
      }
      {
        name = "X-fstrim.notrim";
        value = null;
      }
      {
        name = "x-gvfs-hide";
        value = null;
      }
      {
        name = "x-gdu.hide";
        value = null;
      }
    ];
    parent = {
      group = "users";
      mode = "0750";
      user = "kdn";
    };
    user = "kdn";
  }
]
```

into:
```nix
nix-repl> :p lib.pipe nixosConfigurations.brys.config.preservation.preserveAt [(lib.mapAttrsToList (k: e: e.users.kdn.directories)) lib.flatten (builtins.filter (e: e.directory == "/home/kdn/.local/share/bottles"))]
[
  {
    configureParent = {
      _type = "override";
      content = false;
      priority = 1000;
    };
    directory = "/home/kdn/.local/share/bottles";
    group = {
      _type = "override";
      content = "users";
      priority = 1000;
    };
    how = {
      _type = "override";
      content = "_intermediate";
      priority = 1000;
    };
    inInitrd = false;
    mode = {
      _type = "override";
      content = "0755";
      priority = 1000;
    };
    user = {
      _type = "override";
      content = "kdn";
      priority = 1000;
    };
  }
  {
    configureParent = false;
    createLinkTarget = false;
    directory = "/home/kdn/.local/share/bottles";
    group = "users";
    how = "bindmount";
    inInitrd = false;
    mode = "0750";
    mountOptions = [
      {
        name = "bind";
        value = null;
      }
      {
        name = "X-fstrim.notrim";
        value = null;
      }
      {
        name = "x-gvfs-hide";
        value = null;
      }
      {
        name = "x-gdu.hide";
        value = null;
      }
    ];
    parent = {
      group = "users";
      mode = "0750";
      user = "kdn";
    };
    user = "kdn";
  }
]
```