### PR TITLE
update firstboot examples in docs and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,10 @@ jobs:
         run: nix flake check --log-format raw-with-logs --no-build ./tests
       - name: default test
         run: nix build --log-format raw-with-logs -L ./tests#checks.x86_64-linux.default
-      - name: firstboot test
-        run: nix build --log-format raw-with-logs -L ./tests#checks.x86_64-linux.firstboot
+      - name: firstboot-bind-mount test
+        run: nix build --log-format raw-with-logs -L ./tests#checks.x86_64-linux.firstboot-bind-mount
+      - name: firstboot-symlink test
+        run: nix build --log-format raw-with-logs -L ./tests#checks.x86_64-linux.firstboot-symlink
 
 env:
   FORCE_COLOR: 1

--- a/tests/appliance-image-verity.nix
+++ b/tests/appliance-image-verity.nix
@@ -17,9 +17,19 @@ pkgs:
         enable = true;
         preserveAt."/persistent" = {
           files = [
-            { file = "/etc/machine-id"; inInitrd = true; how = "symlink"; configureParent = true; }
+            {
+              file = "/etc/machine-id";
+              inInitrd = true;
+              how = "symlink";
+              configureParent = true;
+              createLinkTarget = true;
+            }
           ];
         };
+      };
+
+      boot.initrd.systemd.tmpfiles.settings.preservation."/sysroot/persistent/etc/machine-id".f = {
+        argument = "uninitialized";
       };
 
       systemd.services.systemd-machine-id-commit = {
@@ -152,6 +162,8 @@ pkgs:
       with subtest("Machine ID linked and populated"):
         machine.succeed("test -L /etc/machine-id")
         machine.succeed("test -s /persistent/etc/machine-id")
+        machine_id = machine.succeed("cat /etc/machine-id")
+        t.assertNotIn("uninitialized", machine_id, "machine id not populated")
 
       with subtest("Machine ID persisted"):
         first_id = machine.succeed("cat /etc/machine-id")

--- a/tests/appliance-image-verity.nix
+++ b/tests/appliance-image-verity.nix
@@ -17,9 +17,19 @@ pkgs:
         enable = true;
         preserveAt."/persistent" = {
           files = [
-            { file = "/etc/machine-id"; inInitrd = true; how = "symlink"; configureParent = true; }
+            {
+              file = "/etc/machine-id";
+              inInitrd = true;
+              how = "symlink";
+              configureParent = true;
+              createLinkTarget = true;
+            }
           ];
         };
+      };
+
+      boot.initrd.systemd.tmpfiles.settings.preservation."/sysroot/persistent/etc/machine-id".f = {
+        argument = "uninitialized";
       };
 
       systemd.services.systemd-machine-id-commit = {
@@ -148,6 +158,8 @@ pkgs:
       with subtest("Machine ID linked and populated"):
         machine.succeed("test -L /etc/machine-id")
         machine.succeed("test -s /persistent/etc/machine-id")
+        machine_id = machine.succeed("cat /etc/machine-id")
+        t.assertNotEqual("uninitialized", machine_id, "machine id not populated")
 
       with subtest("Machine ID persisted"):
         first_id = machine.succeed("cat /etc/machine-id")

--- a/tests/appliance-image-verity.nix
+++ b/tests/appliance-image-verity.nix
@@ -82,31 +82,27 @@ pkgs:
         passwordFilesLocation = "/persistent/etc";
       };
 
+      fileSystems = {
+        "/" = {
+          fsType = "tmpfs";
+          options = [ "mode=0755" ];
+        };
+        "/persistent" = {
+          device = "/dev/vdb";
+          fsType = "ext4";
+          neededForBoot = true;
+          autoFormat = true;
+        };
+      };
+
       virtualisation = {
         memorySize = 2048;
         emptyDiskImages = [ 23 ];
         directBoot.enable = false;
         mountHostNixStore = false;
         useEFIBoot = true;
-        fileSystems = lib.mkVMOverride {
-          "/" = {
-            fsType = "tmpfs";
-            options = [ "mode=0755" ];
-          };
-          "/nix/store" = {
-            device = "/usr/nix/store";
-            options = [ "bind" ];
-          };
-          "/persistent" = {
-            device = "/dev/vdb";
-            fsType = "ext4";
-            neededForBoot = true;
-            autoFormat = true;
-          };
-        };
+        fileSystems = lib.mkVMOverride { };
       };
-
-      nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform;
     };
 
   testScript =
@@ -125,7 +121,7 @@ pkgs:
         "-f",
         "qcow2",
         "-b",
-        "${nodes.machine.system.build.finalImage}/${nodes.machine.image.fileName}",
+        "${nodes.machine.system.build.image}/${nodes.machine.image.fileName}",
         "-F",
         "raw",
         tmp_disk_image.name,

--- a/tests/basic.nix
+++ b/tests/basic.nix
@@ -128,6 +128,7 @@ in
     /* python */
     ''
       import json
+      import os
 
       initrd_files = json.loads('${initrdJSON}')
       all_files = json.loads('${allJSON}')

--- a/tests/firstboot-bind-mount.nix
+++ b/tests/firstboot-bind-mount.nix
@@ -1,6 +1,6 @@
 pkgs:
 {
-  name = "preservation-firstboot";
+  name = "preservation-firstboot-bind-mount";
 
   nodes.machine =
     { pkgs, ... }:
@@ -9,21 +9,18 @@ pkgs:
 
       preservation = {
         enable = true;
-        preserveAt."/state" = {
+        preserveAt."/persistent" = {
           files = [
-            { file = "/etc/machine-id"; inInitrd = true; how = "symlink"; configureParent = true; }
+            { file = "/etc/machine-id"; inInitrd = true; }
           ];
         };
       };
 
-      systemd.services.systemd-machine-id-commit = {
-        unitConfig.ConditionPathIsMountPoint = [
-          "" "/state/etc/machine-id"
-        ];
-        serviceConfig.ExecStart = [
-          "" "systemd-machine-id-setup --commit --root /state"
-        ];
+      boot.initrd.systemd.tmpfiles.settings.preservation."/sysroot/persistent/etc/machine-id".f = {
+        argument = "uninitialized";
       };
+
+      systemd.services.systemd-machine-id-commit.unitConfig.ConditionFirstBoot = true;
 
       # test-specific configuration below
       boot.initrd.systemd.enable = true;
@@ -34,7 +31,7 @@ pkgs:
         memorySize = 2048;
         # separate block device for preserved state
         emptyDiskImages = [ 23 ];
-        fileSystems."/state" = {
+        fileSystems."/persistent" = {
           device = "/dev/vdb";
           fsType = "ext4";
           neededForBoot = true;
@@ -54,9 +51,10 @@ pkgs:
       with subtest("Initial boot meets ConditionFirstBoot"):
         machine.require_unit_state("first-boot-complete.target","active")
 
-      with subtest("Machine ID linked and populated"):
-        machine.succeed("test -L /etc/machine-id")
-        machine.succeed("test -s /state/etc/machine-id")
+      with subtest("Machine ID populated"):
+        machine.succeed("test -s /persistent/etc/machine-id")
+        machine_id = machine.succeed("cat /etc/machine-id")
+        t.assertNotEqual("uninitialized", machine_id, "machine id not populated")
 
       with subtest("Machine ID persisted"):
         first_id = machine.succeed("cat /etc/machine-id")

--- a/tests/firstboot-symlink.nix
+++ b/tests/firstboot-symlink.nix
@@ -1,0 +1,85 @@
+pkgs:
+{
+  name = "preservation-firstboot-symlink";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ ../module.nix ];
+
+      preservation = {
+        enable = true;
+        preserveAt."/persistent" = {
+          files = [
+            {
+              file = "/etc/machine-id";
+              inInitrd = true;
+              how = "symlink";
+              configureParent = true;
+              createLinkTarget = true;
+            }
+          ];
+        };
+      };
+
+      boot.initrd.systemd.tmpfiles.settings.preservation."/sysroot/persistent/etc/machine-id".f = {
+        argument = "uninitialized";
+      };
+
+      systemd.services.systemd-machine-id-commit = {
+        unitConfig.ConditionPathIsMountPoint = [
+          "" "/persistent/etc/machine-id"
+        ];
+        serviceConfig.ExecStart = [
+          "" "systemd-machine-id-setup --commit --root /persistent"
+        ];
+      };
+
+      # test-specific configuration below
+      boot.initrd.systemd.enable = true;
+
+      networking.useNetworkd = true;
+
+      virtualisation = {
+        memorySize = 2048;
+        # separate block device for preserved state
+        emptyDiskImages = [ 23 ];
+        fileSystems."/persistent" = {
+          device = "/dev/vdb";
+          fsType = "ext4";
+          neededForBoot = true;
+          autoFormat = true;
+        };
+      };
+
+    };
+
+  testScript =
+    { nodes, ... }:
+    # python
+    ''
+      machine.start(allow_reboot=True)
+      machine.wait_for_unit("default.target")
+
+      with subtest("Initial boot meets ConditionFirstBoot"):
+        machine.require_unit_state("first-boot-complete.target","active")
+
+      with subtest("Machine ID linked and populated"):
+        machine.succeed("test -L /etc/machine-id")
+        machine.succeed("test -s /persistent/etc/machine-id")
+        machine_id = machine.succeed("cat /etc/machine-id")
+        t.assertNotEqual("uninitialized", machine_id, "machine id not populated")
+
+      with subtest("Machine ID persisted"):
+        first_id = machine.succeed("cat /etc/machine-id")
+        machine.reboot()
+        machine.wait_for_unit("default.target")
+        second_id = machine.succeed("cat /etc/machine-id")
+        t.assertEqual(first_id, second_id, "machine-id changed")
+
+      with subtest("Second boot does not meet ConditionFirstBoot"):
+        machine.require_unit_state("first-boot-complete.target", "inactive")
+
+      machine.shutdown()
+    '';
+}

--- a/tests/flake.lock
+++ b/tests/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "lastModified": 1762980239,
+        "narHash": "sha256-8oNVE8TrD19ulHinjaqONf9QWCKK+w4url56cdStMpM=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "52a2caecc898d0b46b2b905f058ccc5081f842da",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757068644,
-        "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
+        "lastModified": 1762977756,
+        "narHash": "sha256-4PqRErxfe+2toFJFgcRKZ0UI9NSIOJa+7RXVtBhy4KE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
+        "rev": "c5ae371f1a6a7fd27823bc500d9390b38c05fa55",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "lastModified": 1761765539,
+        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
         "type": "github"
       },
       "original": {

--- a/tests/flake.lock
+++ b/tests/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757068644,
-        "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -16,9 +16,10 @@
         perSystem = { pkgs, ... }:
           {
             checks = {
-              default = pkgs.nixosTest (import ./basic.nix pkgs);
-              firstboot = pkgs.nixosTest (import ./firstboot.nix pkgs);
-              verity-image = pkgs.nixosTest (import ./appliance-image-verity.nix pkgs);
+              default = pkgs.testers.nixosTest (import ./basic.nix pkgs);
+              firstboot-bind-mount = pkgs.testers.nixosTest (import ./firstboot-bind-mount.nix pkgs);
+              firstboot-symlink = pkgs.testers.nixosTest (import ./firstboot-symlink.nix pkgs);
+              verity-image = pkgs.testers.nixosTest (import ./appliance-image-verity.nix pkgs);
             };
           };
       };

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -16,9 +16,9 @@
         perSystem = { pkgs, ... }:
           {
             checks = {
-              default = pkgs.nixosTest (import ./basic.nix pkgs);
-              firstboot = pkgs.nixosTest (import ./firstboot.nix pkgs);
-              verity-image = pkgs.nixosTest (import ./appliance-image-verity.nix pkgs);
+              default = pkgs.testers.runNixOSTest (import ./basic.nix pkgs);
+              firstboot = pkgs.testers.runNixOSTest (import ./firstboot.nix pkgs);
+              verity-image = pkgs.testers.runNixOSTest (import ./appliance-image-verity.nix pkgs);
             };
           };
       };

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -17,7 +17,8 @@
           {
             checks = {
               default = pkgs.testers.runNixOSTest (import ./basic.nix pkgs);
-              firstboot = pkgs.testers.runNixOSTest (import ./firstboot.nix pkgs);
+              firstboot-bind-mount = pkgs.testers.runNixOSTest (import ./firstboot-bind-mount.nix pkgs);
+              firstboot-symlink = pkgs.testers.runNixOSTest (import ./firstboot-symlink.nix pkgs);
               verity-image = pkgs.testers.runNixOSTest (import ./appliance-image-verity.nix pkgs);
             };
           };


### PR DESCRIPTION
Update the firstboot examples in the documentation and tests to be compatible with systemd v258.

Closes https://github.com/nix-community/preservation/issues/22