### PR TITLE
use dedicated tmpfiles services for preservation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,10 @@ jobs:
         run: nix flake check --log-format raw-with-logs --no-build ./tests
       - name: default test
         run: nix build --log-format raw-with-logs -L ./tests#checks.x86_64-linux.default
-      - name: firstboot test
-        run: nix build --log-format raw-with-logs -L ./tests#checks.x86_64-linux.firstboot
+      - name: firstboot-bind-mount test
+        run: nix build --log-format raw-with-logs -L ./tests#checks.x86_64-linux.firstboot-bind-mount
+      - name: firstboot-symlink test
+        run: nix build --log-format raw-with-logs -L ./tests#checks.x86_64-linux.firstboot-symlink
 
 env:
   FORCE_COLOR: 1

--- a/lib.nix
+++ b/lib.nix
@@ -406,6 +406,11 @@ rec {
         ];
         unitConfig.DefaultDependencies = "no";
         conflicts = [ "umount.target" ];
+        after =
+          if forInitrd then
+            [ "systemd-tmpfiles-setup-preservation.service" ]
+          else
+            [ "systemd-tmpfiles-setup-preservation.service" ];
         wantedBy =
           if forInitrd then
             [
@@ -418,7 +423,6 @@ rec {
         before =
           if forInitrd then
             [
-              # directory mounts are set up before tmpfiles
               "systemd-tmpfiles-setup-sysroot.service"
               "initrd-preservation.target"
             ]
@@ -457,11 +461,21 @@ rec {
         conflicts = [ "umount.target" ];
         after =
           if forInitrd then
-            [ "systemd-tmpfiles-setup-sysroot.service" ]
+            [ "systemd-tmpfiles-setup-preservation.service" ]
           else
-            [ "systemd-tmpfiles-setup.service" ];
+            [ "systemd-tmpfiles-setup-preservation.service" ];
         wantedBy = if forInitrd then [ "initrd-preservation.target" ] else [ "preservation.target" ];
-        before = if forInitrd then [ "initrd-preservation.target" ] else [ "preservation.target" ];
+        before =
+          if forInitrd then
+            [
+              "systemd-tmpfiles-setup-sysroot.service"
+              "initrd-preservation.target"
+            ]
+          else
+            [
+              "systemd-tmpfiles-setup.service"
+              "preservation.target"
+            ];
       }) mountedFiles;
 
       mountUnits = directoryMounts ++ fileMounts;
@@ -473,4 +487,84 @@ rec {
   mkInitrdMountUnits = mkMountUnits true;
   mkRegularTmpfilesRules = mkTmpfilesRules false;
   mkInitrdTmpfilesRules = mkTmpfilesRules true;
+
+  mkInitrdTmpfilesService = configPath: persistentStoragePaths: {
+    wantedBy = [ "initrd-preservation.target" ];
+    before = [
+      "initrd.target"
+      "shutdown.target"
+      "initrd-switch-root.target"
+      "systemd-tmpfiles-setup-sysroot.service"
+      "initrd-preservation.target"
+    ];
+    conflicts = [
+      "shutdown.target"
+      "initrd-switch-root.target"
+    ];
+    unitConfig = {
+      DefaultDependencies = false;
+      RefuseManualStop = true;
+      RequiresMountsFor = map (concatTwoPaths "/sysroot") ([ "/etc" ] ++ persistentStoragePaths);
+    };
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStart = "systemd-tmpfiles --create --remove --boot ${configPath}";
+      SuccessExitStatus = "DATAERR CANTCREAT";
+      ImportCredential = [
+        "tmpfiles.*"
+        "login.motd"
+        "login.issue"
+        "network.hosts"
+        "ssh.authorized_keys.root"
+      ];
+    };
+  };
+
+  mkRegularTmpfilesService = onBoot: configPath: persistentStoragePaths: restartTrigger: {
+    wantedBy = lib.optionals onBoot [ "preservation.target" ];
+    requiredBy = lib.optionals (!onBoot) [ "sysinit-reactivation.target" ];
+    after = [
+      "systemd-sysusers.service"
+      "systemd-journald.service"
+    ];
+    before = [
+      "shutdown.target"
+    ]
+    ++ lib.optionals onBoot [
+      "sysinit.target"
+      "initrd-switch-root.target"
+      "systemd-tmpfiles-setup.service"
+      "preservation.target"
+    ]
+    ++ lib.optionals (!onBoot) [
+      "sysinit-reactivation.target"
+      "systemd-tmpfiles-resetup.service"
+    ];
+    conflicts = [
+      "shutdown.target"
+    ]
+    ++ lib.optionals onBoot [
+      "initrd-switch-root.target"
+    ];
+    restartTriggers = lib.optionals (!onBoot) [ restartTrigger ];
+    unitConfig = {
+      DefaultDependencies = false;
+      RefuseManualStop = onBoot;
+      RequiresMountsFor = persistentStoragePaths;
+    };
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStart = "systemd-tmpfiles --create --remove ${lib.optionalString onBoot "--boot"} ${configPath}";
+      SuccessExitStatus = "DATAERR CANTCREAT";
+      ImportCredential = [
+        "tmpfiles.*"
+        "login.motd"
+        "login.issue"
+        "network.hosts"
+        "ssh.authorized_keys.root"
+      ];
+    };
+  };
 }

--- a/module.nix
+++ b/module.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ options, config, lib, pkgs, ... }:
 
 let
   cfg = config.preservation;
@@ -8,7 +8,49 @@ let
     mkInitrdMountUnits
     mkRegularTmpfilesRules
     mkInitrdTmpfilesRules
+    mkInitrdTmpfilesService
+    mkRegularTmpfilesService
     ;
+
+  escapeArgument = lib.strings.escapeC [
+    "\t"
+    "\n"
+    "\r"
+    " "
+    "\\"
+  ];
+
+  settingsEntryToRule = path: entry: ''
+    '${entry.type}' '${path}' '${entry.mode}' '${entry.user}' '${entry.group}' '${entry.age}' ${escapeArgument entry.argument}
+  '';
+
+  pathsToRules = lib.mapAttrsToList (
+    path: types: lib.concatStrings (lib.mapAttrsToList (_type: settingsEntryToRule path) types)
+  );
+
+  mkRuleFileContent =
+    paths:
+    let
+      evalPaths =
+        paths:
+        (lib.evalModules {
+          modules = [
+            {
+              options.settings = lib.mkOption {
+                inherit (options.systemd.tmpfiles.settings) type;
+                default = { };
+              };
+            }
+            { settings.preservation = lib.mkMerge (paths ++ lib.singleton (lib.mkDefault { })); }
+          ];
+        }).config.settings.preservation;
+    in
+    lib.concatStrings (pathsToRules (evalPaths paths));
+
+  configPathSuffix = "preservation.conf";
+  configPath = "/etc/${configPathSuffix}";
+
+  persistentStoragePaths = lib.mapAttrsToList (_: pcfg: pcfg.persistentStoragePath) cfg.preserveAt;
 in
 {
   imports = [
@@ -29,10 +71,11 @@ in
         before = [ "initrd.target" ];
         wantedBy = [ "initrd.target" ];
       };
-      tmpfiles.settings.preservation = lib.mkMerge (
-        lib.flatten (lib.mapAttrsToList mkInitrdTmpfilesRules cfg.preserveAt)
+      contents."${configPath}".source = pkgs.writeText "preservation.conf" (
+        mkRuleFileContent (lib.flatten (lib.mapAttrsToList mkInitrdTmpfilesRules cfg.preserveAt))
       );
       mounts = lib.flatten (lib.mapAttrsToList mkInitrdMountUnits cfg.preserveAt);
+      services.systemd-tmpfiles-setup-preservation = mkInitrdTmpfilesService configPath persistentStoragePaths;
     };
 
     systemd = {
@@ -41,11 +84,19 @@ in
         before = [ "sysinit.target" ];
         wantedBy = [ "sysinit.target" ];
       };
-      tmpfiles.settings.preservation = lib.mkMerge (
-        lib.flatten (lib.mapAttrsToList mkRegularTmpfilesRules cfg.preserveAt)
-      );
       mounts = lib.flatten (lib.mapAttrsToList mkRegularMountUnits cfg.preserveAt);
+      services = {
+        systemd-tmpfiles-setup-preservation =
+          mkRegularTmpfilesService true configPath persistentStoragePaths
+            "";
+        systemd-tmpfiles-resetup-preservation =
+          mkRegularTmpfilesService false configPath persistentStoragePaths
+            config.environment.etc."${configPathSuffix}".source;
+      };
     };
 
+    environment.etc."${configPathSuffix}".source = pkgs.writeText "preservation.conf" (
+      mkRuleFileContent (lib.flatten (lib.mapAttrsToList mkRegularTmpfilesRules cfg.preserveAt))
+    );
   };
 }

--- a/tests/appliance-image-verity.nix
+++ b/tests/appliance-image-verity.nix
@@ -17,9 +17,19 @@ pkgs:
         enable = true;
         preserveAt."/persistent" = {
           files = [
-            { file = "/etc/machine-id"; inInitrd = true; how = "symlink"; configureParent = true; }
+            {
+              file = "/etc/machine-id";
+              inInitrd = true;
+              how = "symlink";
+              configureParent = true;
+              createLinkTarget = true;
+            }
           ];
         };
+      };
+
+      boot.initrd.systemd.tmpfiles.settings.preservation."/sysroot/persistent/etc/machine-id".f = {
+        argument = "uninitialized";
       };
 
       systemd.services.systemd-machine-id-commit = {
@@ -148,6 +158,8 @@ pkgs:
       with subtest("Machine ID linked and populated"):
         machine.succeed("test -L /etc/machine-id")
         machine.succeed("test -s /persistent/etc/machine-id")
+        machine_id = machine.succeed("cat /etc/machine-id")
+        t.assertNotEqual("uninitialized", machine_id, "machine id not populated")
 
       with subtest("Machine ID persisted"):
         first_id = machine.succeed("cat /etc/machine-id")

--- a/tests/appliance-image-verity.nix
+++ b/tests/appliance-image-verity.nix
@@ -82,31 +82,27 @@ pkgs:
         passwordFilesLocation = "/persistent/etc";
       };
 
+      fileSystems = {
+        "/" = {
+          fsType = "tmpfs";
+          options = [ "mode=0755" ];
+        };
+        "/persistent" = {
+          device = "/dev/vdb";
+          fsType = "ext4";
+          neededForBoot = true;
+          autoFormat = true;
+        };
+      };
+
       virtualisation = {
         memorySize = 2048;
         emptyDiskImages = [ 23 ];
         directBoot.enable = false;
         mountHostNixStore = false;
         useEFIBoot = true;
-        fileSystems = lib.mkVMOverride {
-          "/" = {
-            fsType = "tmpfs";
-            options = [ "mode=0755" ];
-          };
-          "/nix/store" = {
-            device = "/usr/nix/store";
-            options = [ "bind" ];
-          };
-          "/persistent" = {
-            device = "/dev/vdb";
-            fsType = "ext4";
-            neededForBoot = true;
-            autoFormat = true;
-          };
-        };
+        fileSystems = lib.mkVMOverride { };
       };
-
-      nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform;
     };
 
   testScript =
@@ -125,7 +121,7 @@ pkgs:
         "-f",
         "qcow2",
         "-b",
-        "${nodes.machine.system.build.finalImage}/${nodes.machine.image.fileName}",
+        "${nodes.machine.system.build.image}/${nodes.machine.image.fileName}",
         "-F",
         "raw",
         tmp_disk_image.name,

--- a/tests/appliance-image-verity.nix
+++ b/tests/appliance-image-verity.nix
@@ -22,13 +22,13 @@ pkgs:
               inInitrd = true;
               how = "symlink";
               configureParent = true;
-              createLinkTarget = true;
+              createLinkTarget = false;
             }
           ];
         };
       };
 
-      boot.initrd.systemd.tmpfiles.settings.preservation."/sysroot/persistent/etc/machine-id".f = {
+      boot.initrd.systemd.tmpfiles.settings.machine-id."/sysroot/persistent/etc/machine-id".f = {
         argument = "uninitialized";
       };
 

--- a/tests/basic.nix
+++ b/tests/basic.nix
@@ -128,6 +128,7 @@ in
     /* python */
     ''
       import json
+      import os
 
       initrd_files = json.loads('${initrdJSON}')
       all_files = json.loads('${allJSON}')

--- a/tests/firstboot-bind-mount.nix
+++ b/tests/firstboot-bind-mount.nix
@@ -1,6 +1,6 @@
 pkgs:
 {
-  name = "preservation-firstboot";
+  name = "preservation-firstboot-bind-mount";
 
   nodes.machine =
     { pkgs, ... }:
@@ -9,21 +9,18 @@ pkgs:
 
       preservation = {
         enable = true;
-        preserveAt."/state" = {
+        preserveAt."/persistent" = {
           files = [
-            { file = "/etc/machine-id"; inInitrd = true; how = "symlink"; configureParent = true; }
+            { file = "/etc/machine-id"; inInitrd = true; }
           ];
         };
       };
 
-      systemd.services.systemd-machine-id-commit = {
-        unitConfig.ConditionPathIsMountPoint = [
-          "" "/state/etc/machine-id"
-        ];
-        serviceConfig.ExecStart = [
-          "" "systemd-machine-id-setup --commit --root /state"
-        ];
+      boot.initrd.systemd.tmpfiles.settings.preservation."/sysroot/persistent/etc/machine-id".f = {
+        argument = "uninitialized";
       };
+
+      systemd.services.systemd-machine-id-commit.unitConfig.ConditionFirstBoot = true;
 
       # test-specific configuration below
       boot.initrd.systemd.enable = true;
@@ -34,7 +31,7 @@ pkgs:
         memorySize = 2048;
         # separate block device for preserved state
         emptyDiskImages = [ 23 ];
-        fileSystems."/state" = {
+        fileSystems."/persistent" = {
           device = "/dev/vdb";
           fsType = "ext4";
           neededForBoot = true;
@@ -54,9 +51,10 @@ pkgs:
       with subtest("Initial boot meets ConditionFirstBoot"):
         machine.require_unit_state("first-boot-complete.target","active")
 
-      with subtest("Machine ID linked and populated"):
-        machine.succeed("test -L /etc/machine-id")
-        machine.succeed("test -s /state/etc/machine-id")
+      with subtest("Machine ID populated"):
+        machine.succeed("test -s /persistent/etc/machine-id")
+        machine_id = machine.succeed("cat /etc/machine-id")
+        t.assertNotEqual("uninitialized", machine_id, "machine id not populated")
 
       with subtest("Machine ID persisted"):
         first_id = machine.succeed("cat /etc/machine-id")

--- a/tests/firstboot-bind-mount.nix
+++ b/tests/firstboot-bind-mount.nix
@@ -16,8 +16,19 @@ pkgs:
         };
       };
 
-      boot.initrd.systemd.tmpfiles.settings.preservation."/sysroot/persistent/etc/machine-id".f = {
-        argument = "uninitialized";
+      # hack for now to populate /sysroot/persistent/etc/machine-id before bind mount
+      boot.initrd.systemd.services.machine-id = {
+        script = ''
+          if [ ! -s /sysroot/persistent/etc/machine-id ]; then
+            echo "uninitialized" > /sysroot/persistent/etc/machine-id
+          fi
+        '';
+        before = [
+          "sysroot-etc-machine\\x2did.mount"
+          "initrd-preservation.target"
+        ];
+        after = [ "systemd-tmpfiles-setup-preservation.service" ];
+        wantedBy = [ "initrd-preservation.target" ];
       };
 
       systemd.services.systemd-machine-id-commit.unitConfig.ConditionFirstBoot = true;

--- a/tests/firstboot-symlink.nix
+++ b/tests/firstboot-symlink.nix
@@ -1,0 +1,85 @@
+pkgs:
+{
+  name = "preservation-firstboot-symlink";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ ../module.nix ];
+
+      preservation = {
+        enable = true;
+        preserveAt."/persistent" = {
+          files = [
+            {
+              file = "/etc/machine-id";
+              inInitrd = true;
+              how = "symlink";
+              configureParent = true;
+              createLinkTarget = true;
+            }
+          ];
+        };
+      };
+
+      boot.initrd.systemd.tmpfiles.settings.preservation."/sysroot/persistent/etc/machine-id".f = {
+        argument = "uninitialized";
+      };
+
+      systemd.services.systemd-machine-id-commit = {
+        unitConfig.ConditionPathIsMountPoint = [
+          "" "/persistent/etc/machine-id"
+        ];
+        serviceConfig.ExecStart = [
+          "" "systemd-machine-id-setup --commit --root /persistent"
+        ];
+      };
+
+      # test-specific configuration below
+      boot.initrd.systemd.enable = true;
+
+      networking.useNetworkd = true;
+
+      virtualisation = {
+        memorySize = 2048;
+        # separate block device for preserved state
+        emptyDiskImages = [ 23 ];
+        fileSystems."/persistent" = {
+          device = "/dev/vdb";
+          fsType = "ext4";
+          neededForBoot = true;
+          autoFormat = true;
+        };
+      };
+
+    };
+
+  testScript =
+    { nodes, ... }:
+    # python
+    ''
+      machine.start(allow_reboot=True)
+      machine.wait_for_unit("default.target")
+
+      with subtest("Initial boot meets ConditionFirstBoot"):
+        machine.require_unit_state("first-boot-complete.target","active")
+
+      with subtest("Machine ID linked and populated"):
+        machine.succeed("test -L /etc/machine-id")
+        machine.succeed("test -s /persistent/etc/machine-id")
+        machine_id = machine.succeed("cat /etc/machine-id")
+        t.assertNotEqual("uninitialized", machine_id, "machine id not populated")
+
+      with subtest("Machine ID persisted"):
+        first_id = machine.succeed("cat /etc/machine-id")
+        machine.reboot()
+        machine.wait_for_unit("default.target")
+        second_id = machine.succeed("cat /etc/machine-id")
+        t.assertEqual(first_id, second_id, "machine-id changed")
+
+      with subtest("Second boot does not meet ConditionFirstBoot"):
+        machine.require_unit_state("first-boot-complete.target", "inactive")
+
+      machine.shutdown()
+    '';
+}

--- a/tests/firstboot-symlink.nix
+++ b/tests/firstboot-symlink.nix
@@ -16,13 +16,13 @@ pkgs:
               inInitrd = true;
               how = "symlink";
               configureParent = true;
-              createLinkTarget = true;
+              createLinkTarget = false;
             }
           ];
         };
       };
 
-      boot.initrd.systemd.tmpfiles.settings.preservation."/sysroot/persistent/etc/machine-id".f = {
+      boot.initrd.systemd.tmpfiles.settings.machine-id."/sysroot/persistent/etc/machine-id".f = {
         argument = "uninitialized";
       };
 

--- a/tests/flake.lock
+++ b/tests/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757068644,
-        "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -16,9 +16,9 @@
         perSystem = { pkgs, ... }:
           {
             checks = {
-              default = pkgs.nixosTest (import ./basic.nix pkgs);
-              firstboot = pkgs.nixosTest (import ./firstboot.nix pkgs);
-              verity-image = pkgs.nixosTest (import ./appliance-image-verity.nix pkgs);
+              default = pkgs.testers.runNixOSTest (import ./basic.nix pkgs);
+              firstboot = pkgs.testers.runNixOSTest (import ./firstboot.nix pkgs);
+              verity-image = pkgs.testers.runNixOSTest (import ./appliance-image-verity.nix pkgs);
             };
           };
       };

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -17,7 +17,8 @@
           {
             checks = {
               default = pkgs.testers.runNixOSTest (import ./basic.nix pkgs);
-              firstboot = pkgs.testers.runNixOSTest (import ./firstboot.nix pkgs);
+              firstboot-bind-mount = pkgs.testers.runNixOSTest (import ./firstboot-bind-mount.nix pkgs);
+              firstboot-symlink = pkgs.testers.runNixOSTest (import ./firstboot-symlink.nix pkgs);
               verity-image = pkgs.testers.runNixOSTest (import ./appliance-image-verity.nix pkgs);
             };
           };


### PR DESCRIPTION
Implementation of the idea mentioned in https://github.com/nix-community/preservation/issues/24.

Note: This PR includes commits from https://github.com/nix-community/preservation/pull/23 for now to ensure tests pass.